### PR TITLE
Flump+

### DIFF
--- a/src/flump/IFlumpMovie.hx
+++ b/src/flump/IFlumpMovie.hx
@@ -11,7 +11,7 @@ interface IFlumpMovie{
 	private function removeFlumpChild(layer:Layer, displayKey:DisplayObjectKey):Void;
 	private function addFlumpChild(layer:Layer, displayKey:DisplayObjectKey):Void;
 
-	private function renderFrame(keyframe:Keyframe, x:Float, y:Float, scaleX:Float, scaleY:Float, skewX:Float, skewY:Float, alpha:Float):Void;
+	private function renderFrame(keyframe:Keyframe, x:Float, y:Float, scaleX:Float, scaleY:Float, skewX:Float, skewY:Float,alpha:Float,tint:Int):Void;
 	private function getChildPlayer(keyframe:Keyframe):MoviePlayer;
 
 	private function onAnimationComplete():Void;

--- a/src/flump/MoviePlayer.hx
+++ b/src/flump/MoviePlayer.hx
@@ -298,6 +298,21 @@ class MoviePlayer{
 				var next = keyframe.next;
 				if(next.isEmpty) next = keyframe; // NASTY! FIX THIS!!
 
+				// tint
+				var lColor:Int;				
+				
+				if (keyframe.tint != next.tint) {					
+					var lPrevR:Int = (keyframe.tint >> 16) & 0xFF;
+					var lPrevG:Int = (keyframe.tint >> 8) & 0xFF;
+					var lPrevB:Int = keyframe.tint & 0xFF;
+					
+					var lNextR:Int = (next.tint >> 16) & 0xFF;
+					var lNextG:Int = (next.tint >> 8) & 0xFF;
+					var lNextB:Int = next.tint & 0xFF;
+					
+					lColor = Math.round(lPrevR + (lNextR - lPrevR) * interped) << 16 | Math.round(lPrevG + (lNextG - lPrevG) * interped) << 8 | Math.round(lPrevB + (lNextB - lPrevB) * interped);
+					
+				} else lColor = keyframe.tint;
 				movie.renderFrame(
 					keyframe,
 					(keyframe.location.x + (next.location.x - keyframe.location.x) * interped),
@@ -306,7 +321,8 @@ class MoviePlayer{
 					(keyframe.scale.y + (next.scale.y - keyframe.scale.y) * interped),
 					keyframe.skew.x + (next.skew.x - keyframe.skew.x) * interped,
 					keyframe.skew.y + (next.skew.y - keyframe.skew.y) * interped,
-					keyframe.alpha + (next.alpha - keyframe.alpha) * interped
+					keyframe.alpha + (next.alpha - keyframe.alpha) * interped,
+					lColor
 				);
 
 

--- a/src/flump/json/FlumpJSON.hx
+++ b/src/flump/json/FlumpJSON.hx
@@ -50,6 +50,7 @@ abstract FlumpRectSpec(Array<Float>){
 typedef MovieSpec = {
 	var layers:Array<LayerSpec>;
 	var id:ReferenceSpec;
+	@:optional var data:Dynamic;
 }
 
 typedef ReferenceSpec = String;
@@ -66,6 +67,8 @@ typedef KeyframeSpec = {
 	var tweened:Bool;
 	var label:String;
 	var alpha:Float;
+	var tint:Array<Dynamic>;
+	@:optional var data:Dynamic;
 }
 
 
@@ -73,6 +76,7 @@ typedef TextureSpec = {
 	var symbol:ReferenceSpec;
 	var rect:FlumpRectSpec;
 	var origin:FlumpPointSpec;
+	@:optional var data:Dynamic;
 }
 
 

--- a/src/flump/library/FlumpLibrary.hx
+++ b/src/flump/library/FlumpLibrary.hx
@@ -58,6 +58,7 @@ class FlumpLibrary{
 			
 				var symbol = new SpriteSymbol();
 				symbol.name = textureSpec.symbol;
+				symbol.data = textureSpec.data;
 				symbol.origin = origin;
 				symbol.texture = textureSpec.symbol;
 				spriteSymbols[symbol.name] = symbol;
@@ -68,6 +69,7 @@ class FlumpLibrary{
 		for(movieSpec in lib.movies){
 			var symbol = new MovieSymbol();
 			symbol.name = movieSpec.id;
+			symbol.data = movieSpec.data;
 			symbol.library = flumpLibrary;
 			for(layerSpec in movieSpec.layers){
 				var layer = new Layer(layerSpec.name);
@@ -101,6 +103,8 @@ class FlumpLibrary{
 						keyframe.scale = keyframeSpec.scale == null ? new Point(1,1) : new Point(keyframeSpec.scale.x, keyframeSpec.scale.y);
 						keyframe.skew = keyframeSpec.skew == null ? new Point(0,0) : new Point(keyframeSpec.skew.x, keyframeSpec.skew.y);
 						keyframe.alpha = keyframeSpec.alpha == null ? 1 : keyframeSpec.alpha;
+						keyframe.tint = keyframeSpec.tint == null ? 0xFFFFFF : Std.parseInt(StringTools.replace(cast(keyframeSpec.tint[1], String), "#", "0x"));
+						
 						keyframe.ease = keyframeSpec.ease == null ? 0 : keyframeSpec.ease;
 					}
 

--- a/src/flump/library/Keyframe.hx
+++ b/src/flump/library/Keyframe.hx
@@ -23,7 +23,8 @@ class Keyframe{
 	public var label:Label;
 	public var isEmpty:Bool;
 	public var alpha:Float;
-	
+	public var data:Dynamic;
+	public var tint:Int;
 	public var next:Keyframe;
 	public var prev:Keyframe;
 	public var nextNonEmptyKeyframe:Keyframe;

--- a/src/flump/library/Symbol.hx
+++ b/src/flump/library/Symbol.hx
@@ -4,6 +4,7 @@ package flump.library;
 class Symbol{
 
 	public var name:String;
+	public var data:Dynamic;
 	
 	public function new(){}
 

--- a/src/pixi/flump/Movie.hx
+++ b/src/pixi/flump/Movie.hx
@@ -300,7 +300,7 @@ class Movie extends Container implements IFlumpMovie {
 	}
 
 
-	private function renderFrame(keyframe:Keyframe, x:Float, y:Float, scaleX:Float, scaleY:Float, skewX:Float, skewY:Float, alpha:Float):Void{
+	private function renderFrame(keyframe:Keyframe, x:Float, y:Float, scaleX:Float, scaleY:Float, skewX:Float, skewY:Float, alpha:Float,tint:Int):Void{
 		var layer = layers[keyframe.layer];
 		
 		layer.pivot.x = keyframe.pivot.x;
@@ -320,7 +320,12 @@ class Movie extends Container implements IFlumpMovie {
 		layer.skew.y = skewY;
 		layer.alpha  = alpha;
 
-
+		if (tint!=0xFFFFFF) {
+			for (child in layer.children) {
+				if (Std.is(child, Sprite)) cast(child, Sprite).tint = tint;
+				else if (Std.is(child, Movie)) cast(child, Movie).tint = tint;
+			}
+		}
 		if(master){
 			//layer.pivot.x /= resolution;
 			//layer.pivot.y /= resolution;
@@ -349,6 +354,22 @@ class Movie extends Container implements IFlumpMovie {
 		player = null;
 		super.destroy(true);
 	}
+	
+	/////////////////////////////////////////////////////
+	//
+	//   custom Data
+	//
+	/////////////////////////////////////////////////////
+	
+	public function getCustomData (): Dynamic {
+		return symbol.data;
+	}
 
-
+	public function getLayerCustomData (layerId:String, keyframeIndex:UInt = 0): Dynamic {
+		var layer = symbol.getLayer(layerId);
+		if(layer == null) throw("Layer " + layerId + " does not exist.");
+		var keyframe = symbol.getLayer(layerId).getKeyframeForFrame(keyframeIndex);
+		if (keyframe == null) throw("Keyframe does not exist at index " + keyframeIndex);
+		return keyframe.data;
+	}
 }

--- a/src/pixi/flump/Sprite.hx
+++ b/src/pixi/flump/Sprite.hx
@@ -9,6 +9,7 @@ class Sprite extends pixi.core.sprites.Sprite{
 	public var symbolId:String;
 	public var resourceId:String;
 	private var resolution:Float;
+	private var data:Dynamic;
 	
 
 	public function new(symbolId:String, resourceId:String = null){
@@ -72,6 +73,14 @@ class Sprite extends pixi.core.sprites.Sprite{
 		scale.y = value * resolution;
 		return value;
 	}
-
-
+	
+	/////////////////////////////////////////////////////
+	//
+	//   custom Data
+	//
+	/////////////////////////////////////////////////////
+	
+	public function getCustomData (): Dynamic {
+		return data;
+	}
 }


### PR DESCRIPTION
adds new features:
- support of custom data available in Flump+ version : https://github.com/mathieuanthoine/pixi-flump-runtime (adds persistent data in Flash/Animate using https://github.com/mathieuanthoine/AnimateCCPersistentDataTools and get it in pixi-flump-runtime with new Sprite/Movie.getCustomData and Movie.getLayerCustomData methods)
- support of tint (got from JSON) and tweens of tint (be careful, Pixi doesn't manage tint like Flash/Animate. You could have weird effects if the texture is not white)
