### PR TITLE
PR#15 breaks normal behaviour

### DIFF
--- a/src/pixi/flump/Movie.hx
+++ b/src/pixi/flump/Movie.hx
@@ -317,14 +317,16 @@ class Movie extends Container implements IFlumpMovie {
 		layer.y = y;
 		
 		// scale applied on child, else the transform may be wrong
-		//layer.scale.x = scaleX;
-		//layer.scale.y = scaleY;
+		layer.scale.x = scaleX;
+		layer.scale.y = scaleY;
+		/*
 		if ( layer.children.length > 0){
 			for ( lChild in layer.children){
 				lChild.scale.x = scaleX;
 				lChild.scale.y = scaleY;
 			}
 		}//else trace( "WARNING : Movie::renderFrame : " + symbol.name + " : " + layer.name + " : empty");
+		*/
 		
 		layer.skew.x = skewX;
 		layer.skew.y = skewY;


### PR DESCRIPTION
Reverse the code in Movie.hx waiting for further investigations.

Behaviour before PR#15 (render in the Flump exporter Preview)
![capture2](https://cloud.githubusercontent.com/assets/6437496/19579788/b5a3adc0-9722-11e6-8f24-a00c9232c05a.PNG)
Behaviour after applied PR#15
![bug](https://cloud.githubusercontent.com/assets/6437496/19579797/c680b778-9722-11e6-8086-cdc674ea838a.PNG)

The Trees at the bottom of the Wind Turbine are not at the right place.

Some keys to investigate:
- Trees are not movies but Sprites
- They are scaled
