### PR TITLE
fix the behaviour of the STATE_PLAYING state of a Movie :

### DIFF
--- a/bin/pixi-flump.js
+++ b/bin/pixi-flump.js
@@ -225,7 +225,12 @@ flump_MoviePlayer.prototype = {
 		this.prevPosition = -1;
 	}
 	,get_position: function() {
-		return (this.elapsed % this.symbol.duration + this.symbol.duration) % this.symbol.duration;
+		var lModPos = (this.elapsed % this.symbol.duration + this.symbol.duration) % this.symbol.duration;
+		var lEndPos;
+		if(this.state == this.STATE_PLAYING) {
+			lEndPos = this.symbol.duration - this.symbol.library.frameTime;
+			if(this.elapsed >= lEndPos) return lEndPos; else return lModPos;
+		} else return lModPos;
 	}
 	,get_totalFrames: function() {
 		return this.symbol.totalFrames;
@@ -347,11 +352,7 @@ flump_MoviePlayer.prototype = {
 		var interped = -1;
 		var lColor = -1;
 		if(this.state == this.STATE_PLAYING) {
-			if(this.get_position() < 0) {
-				this.elapsed = 0;
-				this.stop();
-				this.movie.onAnimationComplete();
-			} else if(this.get_position() >= this.symbol.duration - this.symbol.library.frameTime) {
+			if(this.get_position() >= this.symbol.duration - this.symbol.library.frameTime) {
 				this.elapsed = this.symbol.duration - this.symbol.library.frameTime;
 				this.stop();
 				this.movie.onAnimationComplete();
@@ -388,10 +389,7 @@ flump_MoviePlayer.prototype = {
 				}
 				if(js_Boot.__instanceof(keyframe.symbol,flump_library_MovieSymbol)) {
 					var childMovie = this.movie.getChildPlayer(keyframe);
-					if(childMovie.independantTimeline) {
-						childMovie.advanceTime(this.advanced);
-						childMovie.render();
-					} else {
+					if(childMovie.independantTimeline) childMovie.advanceTime(this.advanced); else {
 						childMovie.elapsed = this.get_position();
 						childMovie.render();
 					}

--- a/src/flump/MoviePlayer.hx
+++ b/src/flump/MoviePlayer.hx
@@ -80,7 +80,15 @@ class MoviePlayer{
 	
 	private var position(get, null):Float = 0.0;
 	public function get_position():Float{
-		return (elapsed % symbol.duration + symbol.duration) % symbol.duration;
+		var lModPos	: Float	= ( elapsed % symbol.duration + symbol.duration) % symbol.duration;
+		var lEndPos	: Float;
+		
+		if ( state == STATE_PLAYING){
+			lEndPos = symbol.duration - symbol.library.frameTime;
+			
+			if ( elapsed >= lEndPos) return lEndPos;
+			else return lModPos;
+		}else return lModPos;
 	}
 
 
@@ -281,12 +289,13 @@ class MoviePlayer{
 		var interped	: Float		= -1;
 		var lColor		:Int		= -1;// AnimateTint
 		
-		if(state == STATE_PLAYING){
-			if(position < 0){
+		if (state == STATE_PLAYING){
+			// "position" could not be negative, this shouldn't occures
+			/*if(position < 0){
 				elapsed = 0;
 				stop();
 				movie.onAnimationComplete();
-			}else if(position >= symbol.duration - symbol.library.frameTime){
+			}else */if(position >= symbol.duration - symbol.library.frameTime){
 				elapsed = symbol.duration - symbol.library.frameTime;
 				stop();
 				movie.onAnimationComplete();
@@ -341,7 +350,7 @@ class MoviePlayer{
 
 					if(childMovie.independantTimeline){
 						childMovie.advanceTime(advanced);
-						childMovie.render();
+						// no need ? "render" call already included at the end of "advanceTime" : childMovie.render();
 					}else{
 						childMovie.elapsed = position;
 						childMovie.render();

--- a/src/flump/filters/AnimateTintFilter.hx
+++ b/src/flump/filters/AnimateTintFilter.hx
@@ -1,5 +1,7 @@
 package flump.filters;
 import pixi.core.renderers.webgl.filters.AbstractFilter;
+// pixi 4 class
+//import pixi.core.renderers.webgl.filters.Filter;
 
 private typedef Uniform = {
 	var type:String;
@@ -22,6 +24,8 @@ private typedef V3 = {
  * @author Mathieu Anthoine
  */
 class AnimateTintFilter extends AbstractFilter
+// pixi 4 class
+//class AnimateTintFilter extends Filter
 {
 
 	public var multiplier (default,null):Float;

--- a/src/pixi/flump/Movie.hx
+++ b/src/pixi/flump/Movie.hx
@@ -308,6 +308,9 @@ class Movie extends Container implements IFlumpMovie {
 		layer.x	= x;
 		layer.y	= y;
 		
+		// pixi 4 hack :)
+		//skewX = -skewX;
+		
 		if ( master){
 			layer.x /= resolution;
 			layer.y /= resolution;


### PR DESCRIPTION
myMovie.loop = false; // the animation did loop sometimes, when fps is low
fix this : https://github.com/jackwlee01/pixi-flump-runtime/issues/22

- the getter of the MoviePlayer::position property takes the state STATE_PLAYING into account
- some adjustments into MoviePlayer::render function

added modifications in comments to easyly switch from pixi3 to pixi4
(see "// pixi 4" comments in Movie.hx and AnimateTintFilter.hx files)