### PR TITLE
homogenize time and frame index calculations

### DIFF
--- a/src/flump/library/FlumpLibrary.hx
+++ b/src/flump/library/FlumpLibrary.hx
@@ -7,7 +7,9 @@ using Lambda;
 
 
 class FlumpLibrary{
-
+	/** accuracy coefficient applied on keyframes' ::time property */
+	static inline var TIME_ACCURACY_COEF						: Float								= 10;
+	
 	public var movies = new Map<String, MovieSymbol>();
 	public var sprites = new Map<String, SpriteSymbol>();
 	public var atlases = new Array<AtlasSpec>();
@@ -88,11 +90,12 @@ class FlumpLibrary{
 					keyframe.duration = keyframeSpec.duration * flumpLibrary.frameTime;
 					keyframe.index = keyframeSpec.index;
 
-					var time = keyframe.index * flumpLibrary.frameTime;
+					/*var time = keyframe.index * flumpLibrary.frameTime;
 					time *= 10;
 					time = Math.floor(time);
 					time /= 10;
-					keyframe.time = time;
+					keyframe.time = time;*/
+					keyframe.time = getTimeAtFrame( keyframe.index, flumpLibrary.frameTime);
 					
 					if(keyframeSpec.ref == null){
 						keyframe.isEmpty = true;
@@ -211,6 +214,13 @@ class FlumpLibrary{
 		return flumpLibrary;
 	}
 
+	/**
+	 * calculate the time at a specified frame index
+	 * @param	pI			frame index ; [ 0 .. totalFrames-1 [
+	 * @param	pFrameTime	duration of a frame, as defined into the considered FlumpLibray instance (FlumpLibray::frameTime)
+	 * @return	time at the specified frame index ; ms
+	 */
+	public static function getTimeAtFrame( pI : Int, pFrameTime : Float) : Float { return Math.floor( pI * pFrameTime * TIME_ACCURACY_COEF) / TIME_ACCURACY_COEF; }
 
 	private static function sortLabel(a:Label, b:Label):Int{
 		if(a.keyframe.index < b.keyframe.index) return -1;

--- a/src/flump/library/Layer.hx
+++ b/src/flump/library/Layer.hx
@@ -26,11 +26,15 @@ class Layer{
 		}
 		return null;
 	}
-
-
-	public function getKeyframeForTime(time:Float){
+	
+	/**
+	 * find the keyframe at a time line position
+	 * @param	time	position of the time line ; ms ; [ 0 .. movie.duration [
+	 * @return	keyframe at this position
+	 */
+	public function getKeyframeForTime( time : Float) : Keyframe {
 		var keyframe = lastKeyframe;
-		while(keyframe.time > time % movie.duration) keyframe = keyframe.prev;
+		while(keyframe.time > time/* % movie.duration*/) keyframe = keyframe.prev;
 		return keyframe;
 	}
 


### PR DESCRIPTION
- some fixes to homogenize time and frame index calculations
- based on the formula used to calculate the ::time property of a keyframe, and on the algorithm used to search the current keyframe to display (Layer::getKeyframeForTime)
- fixes this :
. a Movie instance with its property ::loop set to false will stop playing at currentFrame == totalFrames - 1, and the displayed frame is the final keyframe of the Flash timeline (sometimes it stopped at "totalFrames - 2" ; the displayed final keyframe could be incorrect)
. the ::currentFrame should now have values in this range : [0..totalFrames-1] (sometimes it could exceed the limit)
. piloting / controlling animation with currentFrame should be safer