### PR TITLE
type error in AnimateTintFilter::uniforms.multiplier

### DIFF
--- a/bin/pixi-flump.js
+++ b/bin/pixi-flump.js
@@ -480,7 +480,7 @@ flump_filters_AnimateTintFilter.prototype = $extend(PIXI.AbstractFilter.prototyp
 	,update: function(pColor,pMultiplier) {
 		if(pMultiplier == null) pMultiplier = 1;
 		this.uniforms.color.value = this.hex2v3(this.color = pColor);
-		this.uniforms.multiplier.value = this.multiplier = pMultiplier;
+		if(!(typeof(this.uniforms.multiplier) == "number")) this.uniforms.multiplier.value = this.multiplier = pMultiplier;
 	}
 	,__class__: flump_filters_AnimateTintFilter
 });

--- a/src/flump/filters/AnimateTintFilter.hx
+++ b/src/flump/filters/AnimateTintFilter.hx
@@ -59,7 +59,10 @@ class AnimateTintFilter extends AbstractFilter
 	
 	public function update(pColor:UInt, pMultiplier:Float = 1) : Void {
 		uniforms.color.value = hex2v3(color=pColor);
-		uniforms.multiplier.value = multiplier= pMultiplier;
+		//uniforms.multiplier.value = multiplier= pMultiplier;
+		// this might be a related to different implement of Filter/AbtractFIlter between pixi v4 & v3 ? ; if you don't make this test, you might get a runtime type error with v4
+		// this is just a patch, I 'm not used to the Tint extra feature ; this feature is not tested in v4 yet, so this patch doesn't solve this feature for v4, it just guarantees to run without code crash
+		if ( ! Std.is( uniforms.multiplier, Float)) uniforms.multiplier.value = multiplier= pMultiplier;
 	}
 	
 }


### PR DESCRIPTION
Call to AnimateTintFilter::update by the pixi-flump-runtime makes pixi v4 throw some type error at runtime.

This patch just prevents the error to happen, it just adds an integrity test, so you can run the lib without this error.

It doesn't solve the case, might be related to an incompatibility with the Tint extra feature from pixi v3 to v4 ?